### PR TITLE
add Podium.slugGenerator to specify your own slugGenerator

### DIFF
--- a/src/Podium.php
+++ b/src/Podium.php
@@ -7,6 +7,7 @@ use bizley\podium\maintenance\Maintenance;
 use bizley\podium\models\Activity;
 use bizley\podium\PodiumCache;
 use bizley\podium\PodiumConfig;
+use bizley\podium\slugs\PodiumSluggableBehavior;
 use Yii;
 use yii\base\Action;
 use yii\base\Application;
@@ -21,6 +22,7 @@ use yii\web\Application as WebApplication;
 use yii\web\GroupUrlRule;
 use yii\web\Response;
 use yii\web\User;
+use yii\behaviors\SluggableBehavior;
 
 /**
  * Podium Module
@@ -53,6 +55,7 @@ use yii\web\User;
  * @property PodiumComponent $podiumComponent
  * @property array $loginUrl
  * @property array $registerUrl
+ * @property string $slugGenerator
  */
 class Podium extends Module implements BootstrapInterface
 {
@@ -169,6 +172,13 @@ class Podium extends Module implements BootstrapInterface
      */
     public $denyCallback;
 
+    /**
+     * @var slugGenerator Name of implementation of PodiumSluggableBehavior.
+     * Extend your class from PodiumSluggableBehavior to have access to the type of
+     * slug being generated.
+     * @since x.x
+     */
+    public $slugGenerator = false;
 
     /**
      * Initializes the module for Web application.
@@ -185,6 +195,10 @@ class Podium extends Module implements BootstrapInterface
         } else {
             $this->podiumComponent->registerConsoleComponents();
         }
+        if (!is_string($this->slugGenerator) || $this->slugGenerator != '') {
+            $this->slugGenerator = PodiumSluggableBehavior::className();
+        }
+
     }
 
     /**

--- a/src/Podium.php
+++ b/src/Podium.php
@@ -22,7 +22,6 @@ use yii\web\Application as WebApplication;
 use yii\web\GroupUrlRule;
 use yii\web\Response;
 use yii\web\User;
-use yii\behaviors\SluggableBehavior;
 
 /**
  * Podium Module

--- a/src/Podium.php
+++ b/src/Podium.php
@@ -172,12 +172,12 @@ class Podium extends Module implements BootstrapInterface
     public $denyCallback;
 
     /**
-     * @var slugGenerator Name of implementation of PodiumSluggableBehavior.
-     * Extend your class from PodiumSluggableBehavior to have access to the type of
-     * slug being generated.
-     * @since x.x
+     * @var string Qualified name of class responsible for generating Podium slugs.
+     * You can implement your own generator by extending bizley\podium\slugs\PodiumSluggableBehavior -
+     * see this class for details.
+     * @since 0.8
      */
-    public $slugGenerator = false;
+    public $slugGenerator;
 
     /**
      * Initializes the module for Web application.
@@ -191,13 +191,12 @@ class Podium extends Module implements BootstrapInterface
         if (Yii::$app instanceof WebApplication) {
             $this->podiumComponent->registerComponents();
             $this->layout = 'main';
+            if (!is_string($this->slugGenerator)) {
+                $this->slugGenerator = PodiumSluggableBehavior::className();
+            }
         } else {
             $this->podiumComponent->registerConsoleComponents();
         }
-        if (!is_string($this->slugGenerator) || $this->slugGenerator != '') {
-            $this->slugGenerator = PodiumSluggableBehavior::className();
-        }
-
     }
 
     /**

--- a/src/models/db/CategoryActiveRecord.php
+++ b/src/models/db/CategoryActiveRecord.php
@@ -3,9 +3,10 @@
 namespace bizley\podium\models\db;
 
 use bizley\podium\db\ActiveRecord;
-use yii\behaviors\SluggableBehavior;
 use yii\behaviors\TimestampBehavior;
 use yii\helpers\HtmlPurifier;
+use bizley\podium\Podium;
+use bizley\podium\slugs\PodiumSluggableBehavior;
 
 /**
  * Category model
@@ -41,8 +42,9 @@ class CategoryActiveRecord extends ActiveRecord
         return [
             TimestampBehavior::className(),
             [
-                'class' => SluggableBehavior::className(),
+                'class' => Podium::getInstance()->slugGenerator,
                 'attribute' => 'name',
+                'type' => PodiumSluggableBehavior::CATEGORY
             ]
         ];
     }

--- a/src/models/db/ForumActiveRecord.php
+++ b/src/models/db/ForumActiveRecord.php
@@ -5,7 +5,8 @@ namespace bizley\podium\models\db;
 use bizley\podium\db\ActiveRecord;
 use bizley\podium\models\Category;
 use bizley\podium\models\Post;
-use yii\behaviors\SluggableBehavior;
+use bizley\podium\Podium;
+use bizley\podium\slugs\PodiumSluggableBehavior;
 use yii\behaviors\TimestampBehavior;
 use yii\db\ActiveQuery;
 use yii\helpers\HtmlPurifier;
@@ -46,8 +47,9 @@ class ForumActiveRecord extends ActiveRecord
         return [
             TimestampBehavior::className(),
             [
-                'class' => SluggableBehavior::className(),
+                'class' => Podium::getInstance()->slugGenerator,
                 'attribute' => 'name',
+                'type' => PodiumSluggableBehavior::FORUM
             ]
         ];
     }

--- a/src/models/db/ThreadActiveRecord.php
+++ b/src/models/db/ThreadActiveRecord.php
@@ -11,8 +11,8 @@ use bizley\podium\models\Subscription;
 use bizley\podium\models\ThreadView;
 use bizley\podium\models\User;
 use bizley\podium\Podium;
+use bizley\podium\slugs\PodiumSluggableBehavior;
 use Yii;
-use yii\behaviors\SluggableBehavior;
 use yii\behaviors\TimestampBehavior;
 use yii\helpers\HtmlPurifier;
 
@@ -101,8 +101,9 @@ class ThreadActiveRecord extends ActiveRecord
         return [
             TimestampBehavior::className(),
             [
-                'class' => SluggableBehavior::className(),
+                'class' => Podium::getInstance()->slugGenerator,
                 'attribute' => 'name',
+                'type' => PodiumSluggableBehavior::THREAD
             ],
         ];
     }

--- a/src/models/db/UserActiveRecord.php
+++ b/src/models/db/UserActiveRecord.php
@@ -10,10 +10,10 @@ use bizley\podium\models\Meta;
 use bizley\podium\models\Mod;
 use bizley\podium\models\User;
 use bizley\podium\Podium;
+use bizley\podium\slugs\PodiumSluggableBehavior;
 use Exception;
 use Yii;
 use yii\base\NotSupportedException;
-use yii\behaviors\SluggableBehavior;
 use yii\behaviors\TimestampBehavior;
 use yii\db\ActiveQuery;
 use yii\web\IdentityInterface;
@@ -69,8 +69,9 @@ abstract class UserActiveRecord extends ActiveRecord implements IdentityInterfac
         return [
             TimestampBehavior::className(),
             [
-                'class'     => SluggableBehavior::className(),
+                'class' => Podium::getInstance()->slugGenerator,
                 'attribute' => 'username',
+                'type' => PodiumSluggableBehavior::USER
             ],
         ];
     }

--- a/src/slugs/PodiumSluggableBehavior.php
+++ b/src/slugs/PodiumSluggableBehavior.php
@@ -5,17 +5,44 @@ namespace bizley\podium\slugs;
 use yii\behaviors\SluggableBehavior;
 
 /**
- * Slug generator model
+ * Slug generator behavior
  *
  * To implement your own slug generators create a class that extends
  * PodiumSluggableBehavior and override SluggableBehavior::generateSlug().
  *
- * @author David Newcomb <david.newcomb@bigsoft.co.uk>
- * @since x.x
+ * For example add to configuration:
  *
+ * ```
+ * 'modules' => [
+ *    'podium' => [
+ *       'class' => 'bizley\podium\Podium',
+ *          'slugGenerator' => MyPodiumSlugGenerator::className(),
+ * ```
+ *
+ * and then create a class:
+ *
+ * ```
+ * class MyPodiumSlugGenerator extends PodiumSluggableBehavior
+ * {
+ *
+ *    protected function generateSlug($slugParts)
+ *    {
+ *       if ($this->type == self::THREAD) {
+ *          $s = substr($slugParts[0], 1);
+ *          return str_replace("/", "-", $s);
+ *       } else {
+ *          return parent::generateSlug ( $slugParts );
+ *       }
+ *    }
+ * }
+ * ```
+ *
+ * @author David Newcomb <david.newcomb@bigsoft.co.uk>
+ * @since 0.8
  */
 
-class PodiumSluggableBehavior extends SluggableBehavior {
+class PodiumSluggableBehavior extends SluggableBehavior
+{
 
     const CATEGORY = "category";
     const FORUM = "forum";

--- a/src/slugs/PodiumSluggableBehavior.php
+++ b/src/slugs/PodiumSluggableBehavior.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace bizley\podium\slugs;
+
+use yii\behaviors\SluggableBehavior;
+
+/**
+ * Slug generator model
+ *
+ * To implement your own slug generators create a class that extends
+ * PodiumSluggableBehavior and override SluggableBehavior::generateSlug().
+ *
+ * @author David Newcomb <david.newcomb@bigsoft.co.uk>
+ * @since x.x
+ *
+ */
+
+class PodiumSluggableBehavior extends SluggableBehavior {
+
+    const CATEGORY = "category";
+    const FORUM = "forum";
+    const THREAD = "thread";
+    const USER = "user";
+
+    /**
+     * @var string Use PodiumSluggableBehavior::CATEGORY,...
+     */
+    public $type;
+
+}


### PR DESCRIPTION
This is a solution to #102. It's pretty simple and has the most flexibility.

**main.php**
```
'modules' => [
	'podium' => [
		'class' => 'bizley\podium\Podium',
		'slugGenerator' => MyPodiumSlugGenerator::className(),
	],
```

**MyPodiumSlugGenerator.php**
```
<?php
namespace common\components;

use bizley\podium\slugs\PodiumSluggableBehavior;

class PodiumSlugGenerator extends PodiumSluggableBehavior {

	protected function generateSlug($slugParts) {
		if ($this->type == self::THREAD) {
			$s = substr($slugParts[0], 1);
			return str_replace("/", "-", $s);
		} else {
			return parent::generateSlug ( $slugParts );
		}
	}
}
```
